### PR TITLE
Fix missing access_token attribute in Configuration

### DIFF
--- a/phasetwo/configuration.py
+++ b/phasetwo/configuration.py
@@ -81,7 +81,7 @@ class Configuration(object):
 
     _default = None
 
-    def __init__(self, host=None,
+    def __init__(self, host=None, access_token=None,
                  api_key=None, api_key_prefix=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
@@ -91,6 +91,7 @@ class Configuration(object):
                  ):
         """Constructor
         """
+        self.access_token = access_token
         self._base_path = "https://app.phasetwo.io/auth/realms" if host is None else host
         """Default Base url
         """


### PR DESCRIPTION
The attribute `access_token` in `Configuration` is needed in `Configuration.auth_settings()`.
However, it is never set in `Configuration.__init__()`.

This leads to an exception when you try to make an API call based on a configuration. 
For example, here is a call of `get_webhooks` in the `EventsAPI`:
```
File "...", line 53, in get_webhooks
    api_response = api_instance.get_webhooks(path_params={"realm": realm})
  File "phasetwo/paths/realm_webhooks/get.py", line 255, in get_webhooks
    return self._get_webhooks_oapg(
  File "phasetwo/paths/realm_webhooks/get.py", line 185, in _get_webhooks_oapg
    response = self.api_client.call_api(
  File "phasetwo/api_client.py", line 1137, in call_api
    return self.__call_api(
  File "phasetwo/api_client.py", line 1063, in __call_api
    self.update_params_for_auth(used_headers,
  File "phasetwo/api_client.py", line 1241, in update_params_for_auth
    auth_setting = self.configuration.auth_settings().get(auth)
  File "phasetwo/configuration.py", line 367, in auth_settings
    if self.access_token is not None:
AttributeError: 'Configuration' object has no attribute 'access_token'
```

This pull request adds `access_token` to `Configuration.__init__()` as an optional parameter with default `None`. This way, it is possible to pass `access_token` to `Configuration` so that the authentication for API calls succeeds.